### PR TITLE
Update configureVPN.sh

### DIFF
--- a/configureVPN.sh
+++ b/configureVPN.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Written by Kayden van Rijn
 # Saturday, January 31st 2021


### PR DESCRIPTION
`read -s` is not POSIX compliant.
Change the header to `#! /usr/bin/env bash` instead of `#! /bin/sh` forces the use of BASH where some systems may use a POSIX shell by default.

Addresses issue #1 